### PR TITLE
fix nav height

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,7 +34,7 @@
     padding: 20px;
     background-color: var(--theme);
     max-height: 100%;
-    height: 100%;
+    height: calc(100dvh - var(--header-height));
     overflow: auto;
     margin-right: 20px;
   }


### PR DESCRIPTION
"License" in the nav is hidden under the viewport.

The original height value is `100%`, which is the actual height of the viewport. It didn't take into account the retractable navigation bars on mobiles and in this case, the height of the header.

Setting the height to `100dvh - header height` solves this issue.

About dvh: [Dynamic viewport units](https://developer.chrome.com/blog/whats-new-css-ui-2023/#dynamic-viewport-units)